### PR TITLE
LIBSEARCH-63. Prepended "RDF" module to "register_alias" definitions

### DIFF
--- a/lib/spira/types/date.rb
+++ b/lib/spira/types/date.rb
@@ -20,7 +20,7 @@ module Spira::Types
       RDF::Literal.new(value, :datatype => XSD.date)
     end
 
-    register_alias XSD.date
+    register_alias RDF::XSD.date
 
   end
 end

--- a/lib/spira/types/dateTime.rb
+++ b/lib/spira/types/dateTime.rb
@@ -20,7 +20,7 @@ module Spira::Types
       RDF::Literal.new(value, :datatype => XSD.dateTime)
     end
 
-    register_alias XSD.dateTime
+    register_alias RDF::XSD.dateTime
 
   end
 end

--- a/lib/spira/types/int.rb
+++ b/lib/spira/types/int.rb
@@ -21,7 +21,7 @@ module Spira::Types
       RDF::Literal.new(value, :datatype => XSD.int)
     end
 
-    register_alias XSD.int
+    register_alias RDF::XSD.int
 
   end
 end

--- a/lib/spira/types/long.rb
+++ b/lib/spira/types/long.rb
@@ -21,7 +21,7 @@ module Spira::Types
       RDF::Literal.new(value, :datatype => XSD.long)
     end
 
-    register_alias XSD.long
+    register_alias RDF::XSD.long
 
   end
 end

--- a/lib/spira/types/negativeInteger.rb
+++ b/lib/spira/types/negativeInteger.rb
@@ -21,7 +21,7 @@ module Spira::Types
       RDF::Literal.new(value, :datatype => XSD.negativeInteger)
     end
 
-    register_alias XSD.negativeInteger
+    register_alias RDF::XSD.negativeInteger
 
   end
 end

--- a/lib/spira/types/nonNegativeInteger.rb
+++ b/lib/spira/types/nonNegativeInteger.rb
@@ -21,7 +21,7 @@ module Spira::Types
       RDF::Literal.new(value, :datatype => XSD.nonNegativeInteger)
     end
 
-    register_alias XSD.nonNegativeInteger
+    register_alias RDF::XSD.nonNegativeInteger
 
   end
 end

--- a/lib/spira/types/nonPositiveInteger.rb
+++ b/lib/spira/types/nonPositiveInteger.rb
@@ -21,7 +21,7 @@ module Spira::Types
       RDF::Literal.new(value, :datatype => XSD.nonPositiveInteger)
     end
 
-    register_alias XSD.nonPositiveInteger
+    register_alias RDF::XSD.nonPositiveInteger
 
   end
 end

--- a/lib/spira/types/positiveInteger.rb
+++ b/lib/spira/types/positiveInteger.rb
@@ -21,7 +21,7 @@ module Spira::Types
       RDF::Literal.new(value, :datatype => XSD.positiveInteger)
     end
 
-    register_alias XSD.positiveInteger
+    register_alias RDF::XSD.positiveInteger
 
   end
 end

--- a/lib/spira/types/time.rb
+++ b/lib/spira/types/time.rb
@@ -20,7 +20,7 @@ module Spira::Types
       RDF::Literal.new(value, :datatype => XSD.time)
     end
 
-    register_alias XSD.time
+    register_alias RDF::XSD.time
 
   end
 end


### PR DESCRIPTION
For consistency, modified the "register_alias" method in classes in the
"types" to include the "RDF" module.

This consistency is necessary because the classes in the "types"
subdirectory may be loaded in an arbitrary order. Previous to this
change, the loading of the classes could fail with a
"NameError: uninitialized constant" if a class without the "RDF"
module specified (such as "int.rb") was loaded first.

Prepending the "RDF" module to all register_alias calls where it is
needed prevents this error from occurring, no matter the order in which
the classes are loaded.

https://issues.umd.edu/browse/LIBSEARCH-63