### PR TITLE
LIBSEARCH-63. Prepended "RDF" module to gYear.rb

### DIFF
--- a/lib/spira/types/gYear.rb
+++ b/lib/spira/types/gYear.rb
@@ -20,7 +20,7 @@ module Spira::Types
       RDF::Literal.new(value, :datatype => XSD.gYear)
     end
 
-    register_alias XSD.gYear
+    register_alias RDF::XSD.gYear
 
   end
 end


### PR DESCRIPTION
The fix for this class was missed in the previous updates.

https://issues.umd.edu/browse/LIBSEARCH-63